### PR TITLE
Fix Dynatrace Helm chart value

### DIFF
--- a/package/all.yaml
+++ b/package/all.yaml
@@ -766,9 +766,8 @@ spec:
                 name: dynatrace-operator
                 repository: https://raw.githubusercontent.com/Dynatrace/dynatrace-operator/main/config/helm/repos/stable
                 version: 0.15.0
-                url: ""
               set:
-                - name: installCRDs
+                - name: installCRD
                   value: "true"
                 - name: csidriver.enabled
                   value: "true"


### PR DESCRIPTION
This fixes our Dynatrace operator problem. With this, the CRD can be installed and therefore all pods can be started.